### PR TITLE
Fixed #6 - Issues with the use of "expand" on getTeams()

### DIFF
--- a/packages/client/src/teams/index.ts
+++ b/packages/client/src/teams/index.ts
@@ -4,15 +4,7 @@ import { api, throwError, Options, handleUrl, handleData } from "../util";
 
 export default async function getTeams(options?: Options): Promise<any> {
   const baseUrl = handleUrl("teams", options);
-  let url;
-
-  if (options && options.expand && options.expand.includes("roster")) {
-    url = `${baseUrl}/roster`;
-  } else if (options && options.expand && options.expand.includes("stats")) {
-    url = `${baseUrl}/stats`;
-  } else {
-    url = baseUrl;
-  }
+  let url = baseUrl;
 
   if (options && options.expand) {
     options.expand = `team.${options.expand}`;


### PR DESCRIPTION
Fixes #6 
Instead of appending the /roster or /stats path, we now let ```options.expand = `team.${options.expand}`;``` add an expand query like the [documentation suggests](https://gitlab.com/dword4/nhlapi/blob/master/stats-api.md#teams)